### PR TITLE
Fix markdown plugins

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,23 +1,20 @@
-import { defineConfig } from 'astro/config';
-import starlight from '@astrojs/starlight';
-import starlightThemeFlexoki from 'starlight-theme-flexoki';
-import remarkGemoji from 'remark-gemoji';
-import rehypeTargetBlank from './src/plugins/rehype-target-blank.js';
-
+import { defineConfig } from "astro/config";
+import starlight from "@astrojs/starlight";
+import starlightThemeFlexoki from "starlight-theme-flexoki";
+import remarkGemoji from "remark-gemoji";
+import rehypeTargetBlank from "./src/plugins/rehype-target-blank.js";
 
 export default defineConfig({
-  site: 'https://how-to-git.netlify.app/',
+  site: "https://how-to-git.netlify.app/",
   markdown: {
     remarkPlugins: [remarkGemoji],
+    rehypePlugins: [rehypeTargetBlank],
   },
   integrations: [
     starlight({
-      title: 'How To Git',
-      description: 'A guide to Git',
+      title: "How To Git",
+      description: "A guide to Git",
       plugins: [starlightThemeFlexoki()],
-    })
+    }),
   ],
-  markdown: {
-    rehypePlugins: [rehypeTargetBlank],
-  },
 });

--- a/src/content/docs/02-track-changes.mdx
+++ b/src/content/docs/02-track-changes.mdx
@@ -41,16 +41,16 @@ Clicking on it will open a dialogue window with different fields to fill:
 - **Extended description**: If needed, give more detailed information.
 - Commit directly to the *any name* branch: For now choose this.
 - Create a **new branch** for this commit and start a pull request: Branching out will be described further [down](#branching-out-topics).
-- Agree by clicking on `Commit changes` again.
+- Agree by committing your changes again.
 
 ### Check the history
 In Git, you can view all kinds of changes - whether for a single file, the entire repository, or even across the full network of repositories.
 1. To check the **history of the file** you just modified, open that file in your repository.
-At the top-right corner, above the edit button, you will find a clock icon labeled :clock4:`History`.
+At the top-right corner, above the edit button, you will find a clock icon labeled :clock4: `History`.
 Clicking it will open the history of commits, showing the commit message, the author of the commit and the [SHA](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/about-commits#about-commits), which is a unique identifier for each commit within Git.
 1. To see the **history of all changes in the repository** you are currently working on, go to the repository's main page.
-Under the green `Code` button, you will find another one, labeled :clock4:`Commits`, followed by the number of commits made to the current branch.
+Under the green `Code` button, you will find another one, labeled :clock4: `Commits`, followed by the number of commits made to the current branch.
 By clicking this you can see the same information as in the history of a file, but for all the files of the repository.
-1. There is the possibility to see all kinds of **statistics about the repository** in the Tab :chart_with_upwards_trend:`Insights`.
+1. There is the possibility to see all kinds of **statistics about the repository** in the Tab :chart_with_upwards_trend: `Insights`.
 There you will find an overview, with lots of further options on the left-hand side menu.
 For example, under `Network` you can see the timeline of the most recent commits to the repository, including branches and forks - which are described later in this tutorial.

--- a/src/content/docs/03-plan-work.mdx
+++ b/src/content/docs/03-plan-work.mdx
@@ -24,7 +24,7 @@ You can comment, tag people, add labels, and so much more.
 
 ### Open your first issue
 
-On your repository's main page, click on the Tab labeled :radio_button:`Issues`.
+On your repository's main page, click on the Tab labeled :radio_button: `Issues`.
 Then, at the top-right corner, click on the green button labeled "New issue".
 In the newly opened page for issue creation, you are now asked to provide a title and a description for the issue.
 It is mandatory to give it a title, but even though description is optional, it is strongly recommended to include one, as it will provide more detail.


### PR DESCRIPTION
All plugins must be added & configured in a `markdown` block. We cannot repeat that block twice, otherwise these settings are overwritten.